### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "babel-eslint": "^6.1.2",
     "lodash": "^4.13.1",
     "moment": "^2.13.0",
-    "node-uuid": "^1.4.7",
     "random-altitude": "^1.0.1",
     "random-coordinates": "^1.0.1",
     "random-country": "^1.0.1",
@@ -90,6 +89,7 @@
     "random-longitude": "^1.0.1",
     "read-file-relative": "^1.2.0",
     "rjson-search": "0.0.6",
-    "url": "^0.11.0"
+    "url": "^0.11.0",
+    "uuid": "^3.0.0"
   }
 }

--- a/src/internet.js
+++ b/src/internet.js
@@ -1,4 +1,4 @@
-import nodeUuid from 'node-uuid';
+import nodeUuid from 'uuid';
 import UrlBuilder from './entities/urlBuilder';
 import Alphanumeric from './alpha';
 import UtilityService from './utility';


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.